### PR TITLE
Hotfix habtm foreign keys

### DIFF
--- a/Model/Behavior/LinkableBehavior.php
+++ b/Model/Behavior/LinkableBehavior.php
@@ -117,17 +117,18 @@ class LinkableBehavior extends ModelBehavior {
 								}
 								if (isset($Link->belongsTo[$Reference->alias])) {
 									$referenceLink = $Link->escapeField($Link->belongsTo[$Reference->alias]['foreignKey']);
-								}								
+								}
 							} else {
 								$Link = $_Model->{Inflector::classify($association['joinTable'])};
 							}
 							if (empty($modelLink)) {
-								$modelLink = $Link->escapeField(Inflector::underscore($_Model->alias) . '_id');
+								$modelLink = $Link->escapeField($association['foreignKey']);
 							}
 							if (empty($referenceLink)) {
-								$referenceLink = $Link->escapeField(Inflector::underscore($Reference->alias) . '_id');
+								$referenceLink = $Link->escapeField($association['associationForeignKey']);
 							}
 							$referenceKey = $Reference->escapeField();
+                                                        
 							$query['joins'][] = array(
 								'alias' => $Link->alias,
 								'table' => $Link->table, //$Link->getDataSource()->fullTableName($Link),

--- a/Test/Case/Model/Behavior/LinkableBehaviorTest.php
+++ b/Test/Case/Model/Behavior/LinkableBehaviorTest.php
@@ -17,6 +17,9 @@ class LinkableBehaviorTest extends CakeTestCase {
 		'plugin.linkable.legacy_company',
 		'plugin.linkable.shipment',
 		'plugin.linkable.order_item',
+		'plugin.linkable.news_article',
+		'plugin.linkable.news_category',
+		'plugin.linkable.news_articles_news_category',
 	);
 
 	public $User;
@@ -458,6 +461,40 @@ class LinkableBehaviorTest extends CakeTestCase {
 
 		$this->assertEquals($arrayExpected, $arrayResult, 'belongsTo association with alias (requested), with hasMany to the same model without alias: %s');
 	}
+        
+/**
+ * Ensure that the correct habtm keys are read from the relationship in the models
+ * 
+ * @author David Yell <neon1024@gmail.com>
+ * @return void
+ */
+        public function testHasAndBelongsToManyNonConvention() {
+            $this->NewsArticle = ClassRegistry::init('NewsArticle');
+            
+            $expected = array(
+                array(
+                    'NewsArticle' => array(
+                        'id' => '1',
+                        'title' => 'CakePHP the best framework'
+                    ),
+                    'NewsCategory' => array(
+                        'id' => '1',
+                        'name' => 'Development'
+                    )
+                )
+            );
+            
+            $result = $this->NewsArticle->find('all', array(
+                'link' => array(
+                    'NewsCategory'
+                ),
+                'conditions' => array(
+                    'NewsCategory.id' => 1
+                )
+            ));
+            
+            $this->assertEqual($result, $expected);
+        }
 }
 
 class TestModel extends CakeTestModel {
@@ -556,4 +593,28 @@ class OrderItem extends TestModel {
 			'foreignKey' => 'active_shipment_id',
 		),
 	);
+}
+
+class NewsArticle extends TestModel {
+    public $hasAndBelongsToMany = array(
+        'NewsCategory' => array(
+            'className' => 'NewsCategory',
+            'joinTable' => 'news_articles_news_categories',
+            'foreignKey' => 'article_id',
+            'associationForeignKey' => 'category_id',
+            'unique' => 'keepExisting',
+        )
+    );
+}
+
+class NewsCategory extends TestModel {
+    public $hasAndBelongsToMany = array(
+        'NewsArticle' => array(
+            'className' => 'NewsArticle',
+            'joinTable' => 'news_articles_news_categories',
+            'foreignKey' => 'category_id',
+            'associationForeignKey' => 'article_id',
+            'unique' => 'keepExisting',
+        )
+    );
 }

--- a/Test/Fixture/NewsArticleFixture.php
+++ b/Test/Fixture/NewsArticleFixture.php
@@ -1,0 +1,16 @@
+<?php
+
+class NewsArticleFixture extends CakeTestFixture {
+
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'title' => array('type' => 'string', 'length' => 255, 'null' => false)
+	);
+	
+	public $records = array(
+		array('id' => 1, 'title' => 'CakePHP the best framework'),
+		array('id' => 2, 'title' => 'Zend the oldest framework'),
+		array('id' => 3, 'title' => 'Symfony the engineers framwork'),
+		array('id' => 4, 'title' => 'CodeIgniter wassat?')
+	);
+}

--- a/Test/Fixture/NewsArticlesNewsCategoryFixture.php
+++ b/Test/Fixture/NewsArticlesNewsCategoryFixture.php
@@ -1,0 +1,17 @@
+<?php
+
+class NewsArticlesNewsCategoryFixture extends CakeTestFixture {
+
+	public $fields = array(
+		'article_id' => array('type' => 'integer', 'key' => 'primary'),
+		'category_id' => array('type' => 'integer', 'key' => 'primary'),
+	);
+	
+	public $records = array(
+		array('article_id' => 1, 'category_id' => 1),
+		array('article_id' => 1, 'category_id' => 2),
+		array('article_id' => 2, 'category_id' => 2),
+		array('article_id' => 2, 'category_id' => 3),
+		array('article_id' => 4, 'category_id' => 3),
+	);
+}

--- a/Test/Fixture/NewsCategoryFixture.php
+++ b/Test/Fixture/NewsCategoryFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+class NewsCategoryFixture extends CakeTestFixture {
+
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'name' => array('type' => 'string', 'length' => 255, 'null' => false)
+	);
+	
+	public $records = array(
+		array('id' => 1, 'name' => 'Development'),
+		array('id' => 2, 'name' => 'Programming'),
+		array('id' => 3, 'name' => 'Scripting'),
+	);
+}


### PR DESCRIPTION
**Issue**
When using a HABTM relationship with non-standard foreign keys, the behaviour would generate sql which would fail, because the foreignKey would be assumed.

**Fix**
I've changed the code to read the keys from the habtm relationship.

**Other bits**
I've also tidied up the test class a little, removing all the random tabs, and changing the old underscored methods to use a proper skip method. I've also added a new test which tests the new functionality.
